### PR TITLE
alias: man exits with error code 127

### DIFF
--- a/modules/alias.zsh
+++ b/modules/alias.zsh
@@ -54,13 +54,13 @@ alias weather='() {curl "wttr.in/$1"}' # print weather forecast for current loca
 
 # colorized man
 function man {
-  env \
+  command env \
     LESS_TERMCAP_md=$(printf "${fg_bold[green]}") \
     LESS_TERMCAP_us=$(printf "${fg[cyan]}") \
     LESS_TERMCAP_ue=$(printf "$reset_color") \
     PAGER="${commands[less]:-$PAGER}" \
     _NROFF_U=1 \
-  command man $@
+  man $@
 }
 
 # colorized diff


### PR DESCRIPTION
Alias 'man' fails to execute with the following error message:

‣ man ls
env: ‘command’: No such file or directory
✖ 127

The following pull-request moves the command 'command' to the start of the function to fix this. Tested in ArchLinux.